### PR TITLE
Add bulk game selector for product creation

### DIFF
--- a/app/components/ImportSalesModal.module.css
+++ b/app/components/ImportSalesModal.module.css
@@ -706,6 +706,23 @@
   color: #0284c7;
 }
 
+.bulkGameSelect {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 10px;
+  padding: 8px 12px;
+  background: #e0f2fe;
+  border-radius: 6px;
+}
+
+.bulkGameSelect label {
+  font-size: 12px;
+  font-weight: 500;
+  color: #0369a1;
+  white-space: nowrap;
+}
+
 .createProductsList {
   display: flex;
   flex-direction: column;

--- a/app/components/ImportSalesModal.tsx
+++ b/app/components/ImportSalesModal.tsx
@@ -1128,6 +1128,33 @@ export default function ImportSalesModal({
                   <div className={styles.createProductsHeader}>
                     <h4>🆕 Create Missing Products</h4>
                     <p>These products were not found. Select the ones you want to create:</p>
+                    {filteredGames.length > 0 && (
+                      <div className={styles.bulkGameSelect}>
+                        <label>Assign all to game:</label>
+                        <select
+                          onChange={(e) => {
+                            if (e.target.value) {
+                              // Set all products to this game
+                              const gameId = e.target.value
+                              setProductsToCreate(prev => {
+                                const newMap = new Map(prev)
+                                newMap.forEach((product, key) => {
+                                  const game = filteredGames.find(g => g.id === gameId)
+                                  newMap.set(key, { ...product, gameId, gameName: game?.name || '' })
+                                })
+                                return newMap
+                              })
+                            }
+                          }}
+                          className={styles.gameSelect}
+                        >
+                          <option value="">-- Select game for all --</option>
+                          {filteredGames.map(g => (
+                            <option key={g.id} value={g.id}>{g.name}</option>
+                          ))}
+                        </select>
+                      </div>
+                    )}
                   </div>
                   <div className={styles.createProductsList}>
                     {Array.from(productsToCreate.entries()).map(([key, product]) => (


### PR DESCRIPTION
## Summary
Adds a convenience feature to the CSV import product creation flow:

- "Assign all to game" dropdown to quickly set game for all missing products
- Helpful when importing many products that belong to the same game
- Reminder: Users must select a game for each product before the Create button activates

## Usage
1. Select client in Step 1
2. Upload CSV and map columns
3. In Preview, use "Assign all to game" dropdown OR select games individually
4. Click "Create X Products & Re-process"
5. Rows will update from errors to valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)