### PR TITLE
UX: Add hint for error rows in CSV import

### DIFF
--- a/app/components/ImportSalesModal.module.css
+++ b/app/components/ImportSalesModal.module.css
@@ -511,10 +511,17 @@
 }
 
 .errorList h4 {
-  margin: 0 0 12px;
+  margin: 0 0 4px;
   font-size: 14px;
   font-weight: 600;
   color: #dc2626;
+}
+
+.errorHint {
+  margin: 0 0 12px;
+  font-size: 12px;
+  color: #9ca3af;
+  font-style: italic;
 }
 
 .errorRows {

--- a/app/components/ImportSalesModal.tsx
+++ b/app/components/ImportSalesModal.tsx
@@ -1204,6 +1204,9 @@ export default function ImportSalesModal({
               {invalidRows.length > 0 && (
                 <div className={styles.errorList}>
                   <h4>Rows with Errors (will be skipped)</h4>
+                  <p className={styles.errorHint}>
+                    These may be header rows, month separators, or rows with missing/invalid data.
+                  </p>
                   <div className={styles.errorRows}>
                     {invalidRows.slice(0, 10).map(row => (
                       <div key={row.rowIndex} className={styles.errorRow}>


### PR DESCRIPTION
## Summary
- Added explanatory text under "Rows with Errors" section
- Clarifies these may be header rows, month separators, or rows with missing data
- Helps users understand why rows like "JANUARY", "FEBRUARY" (month labels) are skipped

## Context
When importing CSVs that have section headers or month labels as row separators, many rows show as errors. This hint explains that this is expected behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)