### PR TITLE
Fix PlayStation API scope - use 'data' instead of 'psn:analytics'

### DIFF
--- a/app/api/playstation-api-keys/route.ts
+++ b/app/api/playstation-api-keys/route.ts
@@ -71,7 +71,7 @@ export async function POST(request: Request) {
         .update({
           ps_client_id,
           client_secret,
-          scope: scope || 'psn:analytics',
+          scope: scope || 'data',
           updated_at: new Date().toISOString()
         })
         .eq('client_id', client_id)
@@ -88,7 +88,7 @@ export async function POST(request: Request) {
           client_id,
           ps_client_id,
           client_secret,
-          scope: scope || 'psn:analytics',
+          scope: scope || 'data',
           is_active: true
         })
         .select()
@@ -150,7 +150,8 @@ async function validatePlayStationCredentials(
   try {
     // Create Basic auth header from client_id:client_secret
     const basicAuth = Buffer.from(`${clientId}:${clientSecret}`).toString('base64');
-    const effectiveScope = scope || 'psn:analytics';
+    // Default to 'data' scope - use space-separated values for multiple scopes (e.g., "data dashboard")
+    const effectiveScope = scope || 'data';
 
     console.log('[PlayStation API] Attempting auth to:', PSN_AUTH_URL);
     console.log('[PlayStation API] Using scope:', effectiveScope);

--- a/app/api/playstation-sync/route.ts
+++ b/app/api/playstation-sync/route.ts
@@ -264,7 +264,7 @@ async function getAccessToken(
       },
       body: new URLSearchParams({
         grant_type: 'client_credentials',
-        scope: scope || 'psn:analytics'
+        scope: scope || 'data'  // Use provisioned scope
       })
     });
 

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -114,7 +114,7 @@ export default function SettingsPage() {
     client_id: '',
     ps_client_id: '',
     client_secret: '',
-    scope: 'psn:analytics'
+    scope: 'data'  // Use provisioned scope - can be space-separated for multiple (e.g., "data dashboard")
   });
 
   const [testingPSKey, setTestingPSKey] = useState<string | null>(null);
@@ -465,7 +465,7 @@ export default function SettingsPage() {
 
       if (res.ok) {
         setShowAddPSModal(false);
-        setPsFormData({ client_id: '', ps_client_id: '', client_secret: '', scope: 'psn:analytics' });
+        setPsFormData({ client_id: '', ps_client_id: '', client_secret: '', scope: 'data' });
         fetchData();
       } else {
         const err = await res.json();
@@ -1291,11 +1291,11 @@ export default function SettingsPage() {
               <label>Scope</label>
               <input
                 type="text"
-                placeholder="psn:analytics"
+                placeholder="data"
                 value={psFormData.scope}
                 onChange={e => setPsFormData({...psFormData, scope: e.target.value})}
               />
-              <small>OAuth scope for API access (usually psn:analytics)</small>
+              <small>OAuth scope for API access (e.g., &quot;data&quot; or &quot;data dashboard&quot; for multiple)</small>
             </div>
 
             <div className={styles.modalActions}>


### PR DESCRIPTION
## Summary
Fixed the PlayStation API scope to use the correct provisioned value.

**Problem:** The API was using `psn:analytics` as the default scope, but the provisioned scopes are `data` and `dashboard`.

**Fix:**
- Changed default scope from `psn:analytics` to `data`
- Updated placeholder text in settings UI
- Added note that multiple scopes should be space-separated (e.g., "data dashboard")

## Test plan
- [ ] Try adding PlayStation credentials with scope "data"
- [ ] Should now authenticate successfully (if other credentials are correct)

🤖 Generated with [Claude Code](https://claude.com/claude-code)