### PR TITLE
Simplify auto-calendar: remove Balanced, add preferred start day

### DIFF
--- a/app/components/SaleCalendarPreviewModal.module.css
+++ b/app/components/SaleCalendarPreviewModal.module.css
@@ -18,14 +18,14 @@
   display: flex;
   flex-direction: column;
   box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.25);
-  overflow: hidden; /* Prevent content from overflowing modal */
+  overflow: hidden;
 }
 
 .header {
   padding: 24px 24px 16px;
   border-bottom: 1px solid #e5e7eb;
   position: relative;
-  flex-shrink: 0; /* Prevent shrinking */
+  flex-shrink: 0;
 }
 
 .header h2 {
@@ -130,73 +130,111 @@
   color: #374151;
 }
 
-/* Step Indicator */
-.stepIndicator {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: 0;
-  padding: 16px 24px;
-  background: #f8fafc;
-  border-bottom: 1px solid #e2e8f0;
-  flex-shrink: 0; /* Prevent shrinking */
-}
-
-.step {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  opacity: 0.5;
-  transition: opacity 0.2s;
-}
-
-.step.activeStep {
-  opacity: 1;
-}
-
-.stepNumber {
-  width: 28px;
-  height: 28px;
-  border-radius: 50%;
-  background: #e2e8f0;
-  color: #64748b;
-  font-size: 0.85rem;
-  font-weight: 600;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  transition: all 0.2s;
-}
-
-.activeStep .stepNumber {
-  background: #3b82f6;
-  color: white;
-}
-
-.stepLabel {
-  font-size: 0.9rem;
-  font-weight: 500;
-  color: #64748b;
-}
-
-.activeStep .stepLabel {
-  color: #1e293b;
-}
-
-.stepConnector {
-  width: 60px;
-  height: 2px;
-  background: #e2e8f0;
-  margin: 0 16px;
-}
-
-/* Platform Selection */
-.platformSelection {
+/* Config Screen */
+.configScreen {
   flex: 1;
   overflow-y: auto;
   padding: 20px 24px;
 }
 
+/* Strategy Section */
+.strategySection {
+  margin-bottom: 24px;
+}
+
+.strategySection h3 {
+  margin: 0 0 12px;
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: #1e293b;
+}
+
+.strategyToggle {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 12px;
+}
+
+.strategyOption {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  padding: 20px 16px;
+  border: 3px solid #e2e8f0;
+  border-radius: 14px;
+  background: white;
+  cursor: pointer;
+  transition: all 0.2s;
+  gap: 6px;
+}
+
+.strategyOption:hover {
+  border-color: #cbd5e1;
+  transform: translateY(-2px);
+  box-shadow: 0 6px 16px rgba(0, 0, 0, 0.08);
+}
+
+.strategySelected {
+  border-color: #3b82f6;
+  background: linear-gradient(to bottom, rgba(59, 130, 246, 0.05), white);
+  box-shadow: 0 4px 12px rgba(59, 130, 246, 0.15);
+}
+
+.strategyIcon {
+  font-size: 2rem;
+}
+
+.strategyName {
+  font-weight: 700;
+  font-size: 1.05rem;
+  color: #1e293b;
+}
+
+.strategyDesc {
+  font-size: 0.8rem;
+  color: #64748b;
+  line-height: 1.4;
+}
+
+/* Start Day Section */
+.startDaySection {
+  margin-bottom: 24px;
+  padding-bottom: 24px;
+  border-bottom: 1px solid #e5e7eb;
+}
+
+.startDaySection h3 {
+  margin: 0 0 8px;
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: #1e293b;
+}
+
+.startDayHint {
+  margin: 0 0 12px;
+  font-size: 0.85rem;
+  color: #64748b;
+}
+
+.startDaySelect {
+  padding: 8px 12px;
+  border: 1px solid #d1d5db;
+  border-radius: 8px;
+  background: white;
+  font-size: 0.9rem;
+  color: #1e293b;
+  cursor: pointer;
+  min-width: 180px;
+}
+
+.startDaySelect:focus {
+  outline: none;
+  border-color: #3b82f6;
+  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.1);
+}
+
+/* Platform Selection */
 .platformHeader {
   margin-bottom: 20px;
 }
@@ -343,7 +381,7 @@
   padding: 20px 24px;
   background: linear-gradient(to bottom, #f8fafc, #f1f5f9);
   border-bottom: 1px solid #e2e8f0;
-  flex-shrink: 0; /* Prevent shrinking */
+  flex-shrink: 0;
 }
 
 .selectorTitle {
@@ -356,7 +394,7 @@
 
 .variationCards {
   display: grid;
-  grid-template-columns: repeat(3, 1fr);
+  grid-template-columns: repeat(2, 1fr);
   gap: 16px;
 }
 
@@ -445,7 +483,7 @@
   padding: 16px 24px;
   background: white;
   border-bottom: 1px solid #e5e7eb;
-  flex-shrink: 0; /* Prevent shrinking */
+  flex-shrink: 0;
 }
 
 .quickStat {
@@ -481,7 +519,7 @@
   padding: 12px 24px;
   background: #f8fafc;
   border-bottom: 1px solid #e5e7eb;
-  flex-shrink: 0; /* Prevent shrinking */
+  flex-shrink: 0;
 }
 
 .filterBar label {
@@ -524,8 +562,6 @@
   overflow-y: auto;
   padding: 16px 24px;
   min-height: 100px;
-  /* Remove max-height constraint - let flex handle it */
-  /* The flex: 1 will take remaining space after header, steps, and footer */
 }
 
 .monthGroup {
@@ -631,7 +667,7 @@
   border-top: 1px solid #e5e7eb;
   background: #f9fafb;
   border-radius: 0 0 16px 16px;
-  flex-shrink: 0; /* Prevent footer from shrinking - always visible */
+  flex-shrink: 0;
 }
 
 .footerRight {
@@ -718,67 +754,6 @@
 .applyButton:disabled {
   opacity: 0.5;
   cursor: not-allowed;
-}
-
-/* Responsive */
-@media (max-width: 768px) {
-  .modal {
-    max-height: 95vh;
-  }
-  
-  .variationCards {
-    grid-template-columns: 1fr;
-  }
-  
-  .quickStats {
-    flex-wrap: wrap;
-  }
-  
-  .salesGrid {
-    grid-template-columns: 1fr;
-  }
-  
-  .launchInfo {
-    flex-direction: column;
-  }
-  
-  .headerActions {
-    position: static;
-    margin-top: 12px;
-  }
-  
-  .exportPngButton {
-    width: 100%;
-    justify-content: center;
-  }
-  
-  .platformGrid {
-    grid-template-columns: 1fr;
-  }
-  
-  .stepIndicator {
-    flex-direction: column;
-    gap: 8px;
-  }
-  
-  .stepConnector {
-    width: 2px;
-    height: 20px;
-    margin: 0;
-  }
-  
-  .footer {
-    flex-direction: column;
-  }
-  
-  .footerRight {
-    width: 100%;
-    justify-content: flex-end;
-  }
-  
-  .backButton {
-    flex: 1;
-  }
 }
 
 /* Timeframe Section */
@@ -934,8 +909,46 @@
   border-radius: 6px;
 }
 
-/* Responsive for timeframe */
+/* Responsive */
 @media (max-width: 768px) {
+  .modal {
+    max-height: 95vh;
+  }
+
+  .strategyToggle {
+    grid-template-columns: 1fr;
+  }
+
+  .variationCards {
+    grid-template-columns: 1fr;
+  }
+
+  .quickStats {
+    flex-wrap: wrap;
+  }
+
+  .salesGrid {
+    grid-template-columns: 1fr;
+  }
+
+  .launchInfo {
+    flex-direction: column;
+  }
+
+  .headerActions {
+    position: static;
+    margin-top: 12px;
+  }
+
+  .exportPngButton {
+    width: 100%;
+    justify-content: center;
+  }
+
+  .platformGrid {
+    grid-template-columns: 1fr;
+  }
+
   .timeframeModes {
     flex-direction: column;
   }
@@ -950,138 +963,17 @@
   .dateInput {
     width: 100%;
   }
-}
 
-/* Mode Selection Screen */
-.modeSelection {
-  flex: 1;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  padding: 40px 24px;
-  overflow-y: auto;
-}
-
-.modeTitle {
-  margin: 0 0 32px;
-  font-size: 1.25rem;
-  font-weight: 600;
-  color: #1e293b;
-  text-align: center;
-}
-
-.modeCards {
-  display: grid;
-  grid-template-columns: repeat(2, 1fr);
-  gap: 24px;
-  width: 100%;
-  max-width: 700px;
-}
-
-.modeCard {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  text-align: center;
-  padding: 32px 24px;
-  border: 3px solid #e2e8f0;
-  border-radius: 16px;
-  background: white;
-  cursor: pointer;
-  transition: all 0.2s;
-  gap: 12px;
-}
-
-.modeCard:hover:not(:disabled) {
-  border-color: #3b82f6;
-  transform: translateY(-4px);
-  box-shadow: 0 12px 30px rgba(0, 0, 0, 0.12);
-}
-
-.modeCard:disabled {
-  opacity: 0.5;
-  cursor: not-allowed;
-}
-
-.modeIcon {
-  font-size: 3rem;
-  margin-bottom: 8px;
-}
-
-.modeName {
-  font-size: 1.25rem;
-  font-weight: 700;
-  color: #1e293b;
-}
-
-.modeDesc {
-  font-size: 0.9rem;
-  color: #64748b;
-  line-height: 1.5;
-  max-width: 240px;
-}
-
-.modeDetails {
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
-  margin-top: 8px;
-  padding-top: 16px;
-  border-top: 1px solid #e2e8f0;
-  font-size: 0.85rem;
-  color: #475569;
-}
-
-.modeWarning {
-  margin-top: 24px;
-  padding: 12px 20px;
-  background: #fef3c7;
-  border: 1px solid #fcd34d;
-  border-radius: 8px;
-  font-size: 0.9rem;
-  color: #92400e;
-  text-align: center;
-}
-
-/* Quick Mode Header */
-.quickModeHeader {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: 12px;
-  padding: 12px 24px;
-  background: linear-gradient(135deg, #ecfdf5, #d1fae5);
-  border-bottom: 1px solid #a7f3d0;
-  flex-shrink: 0;
-}
-
-.quickModeBadge {
-  padding: 6px 12px;
-  background: #10b981;
-  color: white;
-  border-radius: 20px;
-  font-size: 0.85rem;
-  font-weight: 600;
-}
-
-.quickModeStrategy {
-  font-size: 0.9rem;
-  font-weight: 500;
-  color: #065f46;
-}
-
-/* Responsive for mode selection */
-@media (max-width: 768px) {
-  .modeCards {
-    grid-template-columns: 1fr;
+  .footer {
+    flex-direction: column;
   }
 
-  .modeCard {
-    padding: 24px 20px;
+  .footerRight {
+    width: 100%;
+    justify-content: flex-end;
   }
 
-  .modeIcon {
-    font-size: 2.5rem;
+  .backButton {
+    flex: 1;
   }
 }

--- a/app/components/TimelineExportModal.tsx
+++ b/app/components/TimelineExportModal.tsx
@@ -23,8 +23,7 @@ type ViewMode = 'table' | 'timeline'
 
 interface VariationSelection {
   current: boolean
-  maxCoverage: boolean
-  balanced: boolean
+  maximizeSales: boolean
   eventsOnly: boolean
 }
 
@@ -42,8 +41,7 @@ export default function TimelineExportModal({
   const [isExporting, setIsExporting] = useState(false)
   const [selectedVariations, setSelectedVariations] = useState<VariationSelection>({
     current: true,
-    maxCoverage: false,
-    balanced: false,
+    maximizeSales: false,
     eventsOnly: false
   })
   
@@ -61,8 +59,7 @@ export default function TimelineExportModal({
   }
   
   // Find variations (may or may not exist)
-  const maxCoverageVariation = calendarVariations.find(v => v.name === 'Maximum Coverage')
-  const balancedVariation = calendarVariations.find(v => v.name === 'Balanced')
+  const maximizeSalesVariation = calendarVariations.find(v => v.name === 'Maximize Sales')
   const eventsOnlyVariation = calendarVariations.find(v => v.name === 'Events Only')
   
   // Get selected datasets
@@ -72,11 +69,8 @@ export default function TimelineExportModal({
     if (selectedVariations.current) {
       datasets.push({ name: 'Current Calendar', sales })
     }
-    if (selectedVariations.maxCoverage && maxCoverageVariation) {
-      datasets.push({ name: 'Maximum Coverage', sales: maxCoverageVariation.sales as unknown as SaleWithDetails[] })
-    }
-    if (selectedVariations.balanced && balancedVariation) {
-      datasets.push({ name: 'Balanced', sales: balancedVariation.sales as unknown as SaleWithDetails[] })
+    if (selectedVariations.maximizeSales && maximizeSalesVariation) {
+      datasets.push({ name: 'Maximize Sales', sales: maximizeSalesVariation.sales as unknown as SaleWithDetails[] })
     }
     if (selectedVariations.eventsOnly && eventsOnlyVariation) {
       datasets.push({ name: 'Events Only', sales: eventsOnlyVariation.sales as unknown as SaleWithDetails[] })
@@ -444,14 +438,14 @@ export default function TimelineExportModal({
             </p>
           </div>
           
-          {/* Calendar Variation Selection - Always show all 3 */}
+          {/* Calendar Variation Selection */}
           <div className={styles.optionGroup}>
             <label className={styles.optionLabel}>Calendar Variations to Export</label>
             <div className={styles.checkboxGroup}>
               {/* Current Calendar - always available */}
               <label className={styles.checkbox}>
-                <input 
-                  type="checkbox" 
+                <input
+                  type="checkbox"
                   checked={selectedVariations.current}
                   onChange={(e) => setSelectedVariations(prev => ({ ...prev, current: e.target.checked }))}
                 />
@@ -460,49 +454,30 @@ export default function TimelineExportModal({
                   <span className={styles.checkboxMeta}>{sales.length} sales</span>
                 </span>
               </label>
-              
-              {/* Maximum Coverage */}
-              <label className={`${styles.checkbox} ${!maxCoverageVariation ? styles.checkboxDisabled : ''}`}>
-                <input 
-                  type="checkbox" 
-                  checked={selectedVariations.maxCoverage}
-                  disabled={!maxCoverageVariation}
-                  onChange={(e) => setSelectedVariations(prev => ({ ...prev, maxCoverage: e.target.checked }))}
+
+              {/* Maximize Sales */}
+              <label className={`${styles.checkbox} ${!maximizeSalesVariation ? styles.checkboxDisabled : ''}`}>
+                <input
+                  type="checkbox"
+                  checked={selectedVariations.maximizeSales}
+                  disabled={!maximizeSalesVariation}
+                  onChange={(e) => setSelectedVariations(prev => ({ ...prev, maximizeSales: e.target.checked }))}
                 />
                 <span className={styles.checkboxLabel}>
-                  <strong>Maximum Coverage</strong>
+                  <strong>Maximize Sales</strong>
                   <span className={styles.checkboxMeta}>
-                    {maxCoverageVariation 
-                      ? `${maxCoverageVariation.stats.totalSales} sales • ${maxCoverageVariation.stats.percentageOnSale}% on sale`
+                    {maximizeSalesVariation
+                      ? `${maximizeSalesVariation.stats.totalSales} sales • ${maximizeSalesVariation.stats.percentageOnSale}% on sale`
                       : 'Generate calendar first'
                     }
                   </span>
                 </span>
               </label>
-              
-              {/* Balanced */}
-              <label className={`${styles.checkbox} ${!balancedVariation ? styles.checkboxDisabled : ''}`}>
-                <input 
-                  type="checkbox" 
-                  checked={selectedVariations.balanced}
-                  disabled={!balancedVariation}
-                  onChange={(e) => setSelectedVariations(prev => ({ ...prev, balanced: e.target.checked }))}
-                />
-                <span className={styles.checkboxLabel}>
-                  <strong>Balanced</strong>
-                  <span className={styles.checkboxMeta}>
-                    {balancedVariation 
-                      ? `${balancedVariation.stats.totalSales} sales • ${balancedVariation.stats.percentageOnSale}% on sale`
-                      : 'Generate calendar first'
-                    }
-                  </span>
-                </span>
-              </label>
-              
+
               {/* Events Only */}
               <label className={`${styles.checkbox} ${!eventsOnlyVariation ? styles.checkboxDisabled : ''}`}>
-                <input 
-                  type="checkbox" 
+                <input
+                  type="checkbox"
                   checked={selectedVariations.eventsOnly}
                   disabled={!eventsOnlyVariation}
                   onChange={(e) => setSelectedVariations(prev => ({ ...prev, eventsOnly: e.target.checked }))}
@@ -510,7 +485,7 @@ export default function TimelineExportModal({
                 <span className={styles.checkboxLabel}>
                   <strong>Events Only</strong>
                   <span className={styles.checkboxMeta}>
-                    {eventsOnlyVariation 
+                    {eventsOnlyVariation
                       ? `${eventsOnlyVariation.stats.totalSales} sales • ${eventsOnlyVariation.stats.percentageOnSale}% on sale`
                       : 'Generate calendar first'
                     }


### PR DESCRIPTION
## Summary
- Remove Quick Generate / Advanced Options mode selector — go straight to config screen
- Remove Balanced strategy (keep Maximize Sales + Events Only)
- Add preferred start day dropdown (default Thursday, customizable Mon-Sun)
- Custom sales snap to preferred day-of-week; event sales keep fixed dates
- Update TimelineExportModal export checkboxes to match 2-strategy system
- Clean up ~300 lines of dead CSS and unused mode-selection code